### PR TITLE
fix: improve pagination handling in loan listing

### DIFF
--- a/src/app/Http/Controllers/LoanController.php
+++ b/src/app/Http/Controllers/LoanController.php
@@ -194,10 +194,13 @@ class LoanController extends Controller
     {
         $validated = request()->validate([
             'per_page' => 'sometimes|integer|min:1|max:100',
+            'page' => 'sometimes|integer|min:1',
         ]);
 
         $perPage = $validated['per_page'] ?? 15; // Default to 15 if not specified or invalid
-        $loans = Loan::paginate($perPage);
+        $page = request()->input('page', 1); // Explicitly get the page from the request
+
+        $loans = Loan::paginate($perPage, ['*'], 'page', $page);
         return LoanResource::collection($loans)->response();
 
     }


### PR DESCRIPTION
fix #11
- Add explicit page parameter validation
- Include page parameter in pagination query
- Set default page to 1 when not specified
- Maintain consistent pagination behavior